### PR TITLE
adds input for users to create a new workout plan

### DIFF
--- a/myFitnessTrainer/App.js
+++ b/myFitnessTrainer/App.js
@@ -53,7 +53,7 @@ export default function App() {
                     options={{ headerTitleAlign: "center" }}
                 />
                 <Stack.Screen
-                    name="Create Fitness Plan"
+                    name="Create Workout Plan"
                     component={CreateNewPlanScreen}
                     options={{ headerTitleAlign: "center" }}
                 />

--- a/myFitnessTrainer/package-lock.json
+++ b/myFitnessTrainer/package-lock.json
@@ -8,6 +8,7 @@
       "name": "myfitnesstrainer",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-picker/picker": "^2.4.10",
         "@react-navigation/drawer": "^6.6.2",
         "@react-navigation/native": "^6.1.6",
         "@react-navigation/native-stack": "^6.9.12",
@@ -18,9 +19,11 @@
         "react": "18.2.0",
         "react-native": "0.71.6",
         "react-native-gesture-handler": "~2.9.0",
+        "react-native-numeric-input": "^1.9.1",
         "react-native-reanimated": "~2.14.4",
         "react-native-safe-area-context": "4.5.0",
-        "react-native-screens": "~3.20.0"
+        "react-native-screens": "~3.20.0",
+        "react-native-vector-icons": "^9.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0",
@@ -6767,6 +6770,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@react-native-picker/picker": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.10.tgz",
+      "integrity": "sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==",
+      "peerDependencies": {
+        "react": ">=16",
+        "react-native": ">=0.57"
       }
     },
     "node_modules/@react-native/assets": {
@@ -18915,6 +18927,26 @@
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.17.tgz",
       "integrity": "sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA=="
     },
+    "node_modules/react-native-numeric-input": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/react-native-numeric-input/-/react-native-numeric-input-1.9.1.tgz",
+      "integrity": "sha512-uJiMjundXHiBcBLHgSqbfSjLdBM+4OBgLJLSsYG5/+XST5XWufsU8eZaEsn1miOkhjj2B7WgshjNX2Qm+4n3kw==",
+      "dependencies": {
+        "prop-types": "^15.6.1",
+        "react-native-pixel-perfect": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react-native-vector-icons": "^9.*"
+      }
+    },
+    "node_modules/react-native-pixel-perfect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-pixel-perfect/-/react-native-pixel-perfect-1.0.2.tgz",
+      "integrity": "sha512-0IvYCNkxuQbQC9q4tI+C3i6o38nbx916p7gBRBWuPxDhKBCuTkVV3VukcfW6vtjRlwQm6kwQcF9OtI+yUBt+YA==",
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-reanimated": {
       "version": "2.14.4",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz",
@@ -18954,6 +18986,73 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-vector-icons": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
+      "integrity": "sha512-wKYLaFuQST/chH3AJRjmOLoLy3JEs1JR6zMNgTaemFpNoXs0ztRnTxcxFD9xhX7cJe1/zoN5BpQYe7kL0m5yyA==",
+      "dependencies": {
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "bin": {
+        "fa5-upgrade": "bin/fa5-upgrade.sh",
+        "generate-icon": "bin/generate-icon.js"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native/node_modules/promise": {
@@ -26614,6 +26713,12 @@
       "requires": {
         "joi": "^17.2.1"
       }
+    },
+    "@react-native-picker/picker": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@react-native-picker/picker/-/picker-2.4.10.tgz",
+      "integrity": "sha512-EvAlHmPEPOwvbP6Pjg/gtDV3XJzIjIxr10fXFNlX5r9HeHw582G1Zt2o8FLyB718nOttgj8HYUTGxvhu4N65sQ==",
+      "requires": {}
     },
     "@react-native/assets": {
       "version": "1.0.0",
@@ -35803,6 +35908,21 @@
       "resolved": "https://registry.npmjs.org/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.17.tgz",
       "integrity": "sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA=="
     },
+    "react-native-numeric-input": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/react-native-numeric-input/-/react-native-numeric-input-1.9.1.tgz",
+      "integrity": "sha512-uJiMjundXHiBcBLHgSqbfSjLdBM+4OBgLJLSsYG5/+XST5XWufsU8eZaEsn1miOkhjj2B7WgshjNX2Qm+4n3kw==",
+      "requires": {
+        "prop-types": "^15.6.1",
+        "react-native-pixel-perfect": "^1.0.1"
+      }
+    },
+    "react-native-pixel-perfect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-pixel-perfect/-/react-native-pixel-perfect-1.0.2.tgz",
+      "integrity": "sha512-0IvYCNkxuQbQC9q4tI+C3i6o38nbx916p7gBRBWuPxDhKBCuTkVV3VukcfW6vtjRlwQm6kwQcF9OtI+yUBt+YA==",
+      "requires": {}
+    },
     "react-native-reanimated": {
       "version": "2.14.4",
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz",
@@ -35830,6 +35950,59 @@
       "requires": {
         "react-freeze": "^1.0.0",
         "warn-once": "^0.1.0"
+      }
+    },
+    "react-native-vector-icons": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.2.0.tgz",
+      "integrity": "sha512-wKYLaFuQST/chH3AJRjmOLoLy3JEs1JR6zMNgTaemFpNoXs0ztRnTxcxFD9xhX7cJe1/zoN5BpQYe7kL0m5yyA==",
+      "requires": {
+        "prop-types": "^15.7.2",
+        "yargs": "^16.1.1"
+      },
+      "dependencies": {
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+        }
       }
     },
     "react-refresh": {

--- a/myFitnessTrainer/package.json
+++ b/myFitnessTrainer/package.json
@@ -20,19 +20,22 @@
     ]
   },
   "dependencies": {
+    "@react-native-picker/picker": "^2.4.10",
     "@react-navigation/drawer": "^6.6.2",
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "expo": "~48.0.11",
+    "expo-image-picker": "~14.1.1",
     "expo-status-bar": "~1.4.4",
     "firebase": "^9.20.0",
     "react": "18.2.0",
     "react-native": "0.71.6",
     "react-native-gesture-handler": "~2.9.0",
+    "react-native-numeric-input": "^1.9.1",
     "react-native-reanimated": "~2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
-    "expo-image-picker": "~14.1.1"
+    "react-native-vector-icons": "^9.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/myFitnessTrainer/src/components/CreateNewPlanButton.js
+++ b/myFitnessTrainer/src/components/CreateNewPlanButton.js
@@ -6,12 +6,12 @@ const CreateNewPlanButton = () => {
     const navigation = useNavigation();
 
     const handleCreateNewPlan = () => {
-        navigation.replace("Create Fitness Plan");
+        navigation.navigate("Create Workout Plan");
     };
 
     return (
         <TouchableOpacity style={styles.button} onPress={handleCreateNewPlan}>
-            <Text style={styles.buttonText}>Create New Fitness Plan</Text>
+            <Text style={styles.buttonText}>Create New Workout Plan</Text>
         </TouchableOpacity>
     );
 };

--- a/myFitnessTrainer/src/components/GenerateNewPlanAlgoButton.js
+++ b/myFitnessTrainer/src/components/GenerateNewPlanAlgoButton.js
@@ -120,7 +120,7 @@ const GenerateNewPlanAlgoButton = ({
             style={styles.button}
             onPress={handleCreateNewPlanAlgo}
         >
-            <Text style={styles.buttonText}>Generate Fitness Plan</Text>
+            <Text style={styles.buttonText}>Create Workout Plan</Text>
         </TouchableOpacity>
     );
 };

--- a/myFitnessTrainer/src/screens/CreateNewPlanScreen.js
+++ b/myFitnessTrainer/src/screens/CreateNewPlanScreen.js
@@ -1,4 +1,4 @@
-import { StyleSheet, View, Text, Platform } from "react-native";
+import { StyleSheet, View, Text, Platform, ScrollView } from "react-native";
 import { Picker } from '@react-native-picker/picker';
 import NumericInput from 'react-native-numeric-input';
 import { useState } from "react";
@@ -87,34 +87,36 @@ const CreateNewPlanScreen = () => {
     );
 
     return (
-        <View style={styles.container}>
-            <Text style={styles.IntroText}>Customize your options to create a new workout plan</Text>
-            <View style={styles.centeredInputContainer}>
-                <View style={{flexDirection:"row"}}>
-                    <Text style={styles.optionHeaderText}>Workout Plan Duration </Text>
-                    <Text style={{paddingTop: 10}}>(in days)</Text>
+        <ScrollView>
+            <View style={styles.container}>
+                <Text style={styles.IntroText}>Customize your options to create a new workout plan</Text>
+                <View style={styles.centeredInputContainer}>
+                    <View style={{flexDirection:"row"}}>
+                        <Text style={styles.optionHeaderText}>Workout Plan Duration </Text>
+                        <Text style={{paddingTop: 10}}>(in days)</Text>
+                    </View>
+                    
+                    {durationInput}
+                    <Text style={styles.optionHeaderText}>Exercises Per Day</Text>
+                    {exercisesPerDayInput}
                 </View>
-                
-                {durationInput}
-                <Text style={styles.optionHeaderText}>Exercises Per Day</Text>
-                {exercisesPerDayInput}
+                <Text style={styles.optionHeaderText}>Fitness Goal</Text>
+                {fitnessGoalPicker}
+                <Text style={styles.optionHeaderText}>Fitness Level</Text>
+                {fitnessLevelPicker}
+                <Text style={styles.optionHeaderText}>Modifications</Text>
+                {modificationPicker}
+                <View style={styles.buttonContainer}>
+                    <GenerateNewPlanAlgoButton
+                        goal={fitnessGoal}
+                        level={fitnessLevel}
+                        duration={duration}
+                        exercisesPerDay={exercisesPerDay}
+                        modification={modification}
+                    />
+                </View>
             </View>
-            <Text style={styles.optionHeaderText}>Fitness Goal</Text>
-            {fitnessGoalPicker}
-            <Text style={styles.optionHeaderText}>Fitness Level</Text>
-            {fitnessLevelPicker}
-            <Text style={styles.optionHeaderText}>Modifications</Text>
-            {modificationPicker}
-            <View style={styles.buttonContainer}>
-                <GenerateNewPlanAlgoButton
-                    goal={fitnessGoal}
-                    level={fitnessLevel}
-                    duration={duration}
-                    exercisesPerDay={exercisesPerDay}
-                    modification={modification}
-                />
-            </View>
-        </View>
+        </ScrollView>
     );
 };
 

--- a/myFitnessTrainer/src/screens/CreateNewPlanScreen.js
+++ b/myFitnessTrainer/src/screens/CreateNewPlanScreen.js
@@ -1,11 +1,119 @@
-import { StyleSheet, View, Text } from "react-native";
+import { StyleSheet, View, Text, Platform } from "react-native";
+import { Picker } from '@react-native-picker/picker';
+import NumericInput from 'react-native-numeric-input';
+import { useState } from "react";
 import GenerateNewPlanAlgoButton from "../components/GenerateNewPlanAlgoButton";
 
+const fitnessGoals = ['strength', 'cardio', 'flexibility'];
+const fitnessLevels = ['beginner', 'intermediate', 'advanced'];
+const modifications = [null, 'upper body only', 'lower body only'];
+
 const CreateNewPlanScreen = () => {
+    const [fitnessGoal, setFitnessGoal] = useState(fitnessGoals[0]);
+    const [fitnessLevel, setFitnessLevel] = useState(fitnessLevels[0]);
+    const [duration, setDuration] = useState(10);
+    const [exercisesPerDay, setExercisesPerDay] = useState(4);
+    const [modification, setModification] = useState(modifications[0]);
+
+    const fitnessGoalPicker = (
+        <Picker
+            selectedValue={fitnessGoal}
+            onValueChange={goal => setFitnessGoal(goal)}
+            style={styles.picker}
+            itemStyle={styles.iosItemStyle}
+        >
+            {
+                fitnessGoals.map((goal, index) => (
+                    <Picker.Item key={index} label={goal} value={goal}/>
+                ))
+            }
+        </Picker>
+    );
+
+    const fitnessLevelPicker = (
+        <Picker
+            selectedValue={fitnessLevel}
+            onValueChange={level => setFitnessLevel(level)}
+            style={styles.picker}
+            itemStyle={styles.iosItemStyle}
+        >
+            {
+                fitnessLevels.map((level, index) => (
+                    <Picker.Item key={index} label={level} value={level}/>
+                ))
+            }
+        </Picker>
+    );
+
+    const modificationPicker = (
+        <Picker
+            selectedValue={modification}
+            onValueChange={mod => setModification(mod)}
+            style={styles.picker}
+            itemStyle={styles.iosItemStyle}
+        >
+            {
+                modifications.map((mod, index) => (
+                    <Picker.Item key={index} label={mod == null ? 'none' : mod} value={mod}/>
+                ))
+            }
+        </Picker>
+    );
+    
+    const durationInput = (
+        <NumericInput 
+            value={duration}
+            onChange={value => setDuration(value)}
+            minValue={1}
+            maxValue={999}
+            totalWidth={300}
+            totalHeight={50}
+            style={{paddingBottom: 10}}
+            step={1}
+        />
+    );
+
+    const exercisesPerDayInput = (
+        <NumericInput 
+            value={exercisesPerDay}
+            onChange={value => setExercisesPerDay(value)}
+            minValue={1}
+            maxValue={15}
+            totalWidth={300}
+            totalHeight={50}
+            style={{paddingBottom: 10}}
+            
+        />
+    );
+
     return (
         <View style={styles.container}>
-            <Text>Create New Plan Screen placeholder</Text>
-            <GenerateNewPlanAlgoButton />
+            <Text style={styles.IntroText}>Customize your options to create a new workout plan</Text>
+            <View style={styles.centeredInputContainer}>
+                <View style={{flexDirection:"row"}}>
+                    <Text style={styles.optionHeaderText}>Workout Plan Duration </Text>
+                    <Text style={{paddingTop: 10}}>(in days)</Text>
+                </View>
+                
+                {durationInput}
+                <Text style={styles.optionHeaderText}>Exercises Per Day</Text>
+                {exercisesPerDayInput}
+            </View>
+            <Text style={styles.optionHeaderText}>Fitness Goal</Text>
+            {fitnessGoalPicker}
+            <Text style={styles.optionHeaderText}>Fitness Level</Text>
+            {fitnessLevelPicker}
+            <Text style={styles.optionHeaderText}>Modifications</Text>
+            {modificationPicker}
+            <View style={styles.buttonContainer}>
+                <GenerateNewPlanAlgoButton
+                    goal={fitnessGoal}
+                    level={fitnessLevel}
+                    duration={duration}
+                    exercisesPerDay={exercisesPerDay}
+                    modification={modification}
+                />
+            </View>
         </View>
     );
 };
@@ -13,9 +121,41 @@ const CreateNewPlanScreen = () => {
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
+        padding: 10
     },
+    IntroText: {
+        fontSize: 15,
+        textAlign: "center",
+        marginBottom: 5
+    },
+    buttonContainer: {
+        flex: 1,
+        alignItems: 'center'
+    },
+    optionHeaderText: {
+        fontSize: 18, 
+        fontWeight: "bold",
+        paddingTop: 8, 
+        paddingBottom: 10
+    },
+    picker: {
+        backgroundColor: Platform.OS == "android" ? "white" : ""
+    },
+    iosItemStyle : {
+        height: 110
+    },
+    centeredInputContainer: {
+        alignItems: "center",
+        justifyContent: "center"
+    },
+    durationInput: {
+        backgroundColor: "white",
+        width: 250,
+        textAlign: "center",
+        fontSize: 18,
+        padding: 10,
+        marginTop: 10
+    }
 });
 
 export default CreateNewPlanScreen;

--- a/myFitnessTrainer/src/screens/CreateNewPlanScreen.js
+++ b/myFitnessTrainer/src/screens/CreateNewPlanScreen.js
@@ -123,7 +123,8 @@ const CreateNewPlanScreen = () => {
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        padding: 10
+        padding: 20,
+        paddingBottom: 40
     },
     IntroText: {
         fontSize: 15,

--- a/myFitnessTrainer/src/screens/DashboardScreen.js
+++ b/myFitnessTrainer/src/screens/DashboardScreen.js
@@ -2,14 +2,16 @@ import { StyleSheet, Text, View } from 'react-native';
 import React from 'react';
 import { auth } from '../../firebaseConfig';
 import StartWorkoutButton from "../components/StartWorkoutButton";
+import CreateNewPlanButton from '../components/CreateNewPlanButton';
 
 
 const DashboardScreen = () => {
-    // TO DO: SIGN OUT BUTTON TO BE MOVED TO SETTINGS...HERE FOR TESTING
+    // TODO: WILL SHOW CREATE NEW PLAN OR START WORKOUT BUTTON DEPENDING ON IF THEY HAVE ACTIVE PLAN
     return (
         <View style={styles.container}>
             <Text>Email: {auth.currentUser?.email}</Text>
             <Text>This screen is the Dashboard! Woot!</Text>
+            <CreateNewPlanButton />
             <StartWorkoutButton />
 
         </View>


### PR DESCRIPTION
Uses cross-platform input selectors for users to create their workout plan.
- Noticed some inconsistency with using fitness plan vs. workout plan language. Switched to use only 'workout plan'. 
- Sends their selections to the `GenerateNewPlanAlgoButton`, already created (woot woot). 
- I set up default selections for all of these inputs, which is nice because it means less clicks if the user is happy with the selection.
- only selection that is a little funky is the modification - if it is 'none', we send null. Otherwise we'll send a string of either 'upper body only' or 'lower body only'.

Also, added a `TODO `comment in Dashboard about having it either show the create new plan or the start workout button, depending on whether they have an active plan. This will be addressed later in an existing task for the dashboard work.